### PR TITLE
Implement collision layers and masks

### DIFF
--- a/src/gameObjects/physicsObjects.ts
+++ b/src/gameObjects/physicsObjects.ts
@@ -4,8 +4,6 @@ import { log } from "../index";
 import { CollisionData, PhysicsEngine } from "../physicsEngine/physics";
 
 export class AABB extends Sprite {
-  protected enabled;
-
   /**
    * Creates an Axis-Aligned Bounding Box.
    * @param {Vector2} position The initial position of the collider
@@ -15,11 +13,7 @@ export class AABB extends Sprite {
    */
   constructor(position: Vector2, size: Vector2, enabled: boolean, name: string) {
     super(position, size, name);
-    this.enabled = enabled;
-  }
-
-  isEnabled(): boolean {
-    return this.enabled;
+    this.visible = enabled;
   }
 }
 
@@ -27,7 +21,7 @@ export class CollisionObject extends Sprite {
   protected collisionMask: number = 0b1; // Same as 0b0000000001
   protected collisionLayer: number = 0b1;
 
-  constructor(position: Vector2, size: Vector2, collisionMask: number, collisionLayer: number, name: string) {
+  constructor(position: Vector2, size: Vector2, collisionLayer: number, collisionMask: number, name: string) {
     super(position, size, name);
     this.collisionMask = collisionMask;
     this.collisionLayer = collisionLayer;
@@ -74,8 +68,8 @@ export class CollisionObject extends Sprite {
 export class Region extends CollisionObject {
   protected regionsInside: Region[] = [];
 
-  constructor(position: Vector2, size: Vector2, name: string) {
-    super(position, size, 0b1, 0b1, name);
+  constructor(position: Vector2, size: Vector2, collisionLayer: number, collisionMask: number, name: string) {
+    super(position, size, collisionLayer, collisionLayer, name);
   }
 
   interactWithRegion(region: Region): void {
@@ -107,8 +101,9 @@ export class RigidBody extends Region {
   protected friction: number = 0.8;
   protected lastFrameCollisions: CollisionData[] = [];
 
-  constructor(position: Vector2, size: Vector2, friction: number, name: string) {
-    super(position, size, name);
+  constructor(position: Vector2, size: Vector2, collisionLayer: number, collisionMask: number, friction: number, name: string) {
+    super(position, size, collisionLayer, collisionMask, name);
+    this.friction = friction;
   }
 
   public resetFrameColisions(): void {
@@ -132,8 +127,8 @@ export class RigidBody extends Region {
 }
 
 export class StaticBody extends RigidBody {
-  constructor(position: Vector2, size: Vector2, friction: number, name: string) {
-    super(position, size, friction, name);
+  constructor(position: Vector2, size: Vector2, collisionLayer: number, collisionMask: number, friction: number, name: string) {
+    super(position, size, collisionLayer, collisionMask, friction, name);
     this.friction = friction;
   }
 }
@@ -142,8 +137,8 @@ export class KinematicBody extends RigidBody {
   protected pushable: boolean;
   protected velocity: Vector2;
 
-  constructor(position: Vector2, size: Vector2, velocity: Vector2, pushable: boolean, friction: number, name: string) {
-    super(position, size, friction, name);
+  constructor(position: Vector2, size: Vector2, collisionLayer: number, collisionMask: number, velocity: Vector2, pushable: boolean, friction: number, name: string) {
+    super(position, size, collisionLayer, collisionMask, friction, name);
     this.velocity = velocity;
     this.pushable = pushable;
   }

--- a/src/physicsEngine/physics.ts
+++ b/src/physicsEngine/physics.ts
@@ -467,11 +467,22 @@ export class PhysicsEngine {
         return value.colliderA === spr || value.colliderB === spr;
       });
 
+      const sprCollider = spr.getChildrenType<AABB>(AABB)[0];
+      const spriteCollider = sprite.getChildrenType<AABB>(AABB)[0];
+
+      log("spr: ", spr.getName(), " sprite: ", sprite.getName());
+      log("spriteColliderName: ", spriteCollider.getName());
+      log("sprColliderVisible: ", sprCollider.isVisible(), " SpriteColliderVisible: ", spriteCollider.isVisible());
+      log("sprCollisionLayer: ", spr.getCollisionLayer(), " sprCollisionMask: ", spr.getCollisionMask());
+      log("spriteCollisionLayer: ", sprite.getCollisionLayer(), " spriteCollisionMask: ", sprite.getCollisionMask());
+      log("Spr & Sprite: ", spr.getCollisionLayer() & sprite.getCollisionMask(), " Sprite & spr: ", sprite.getCollisionLayer() & spr.getCollisionMask());
       if (
         spr != sprite &&
         spriteExcludeList.indexOf(spr) == -1 &&
         (previousCollision === undefined || alreadyCollided === undefined) &&
-        PhysicsEngine.staticAABB(broadBox, spr.getChildrenType<AABB>(AABB)[0])
+        (sprCollider.isVisible() && spriteCollider.isVisible()) &&
+        (spr.getCollisionLayer() & sprite.getCollisionMask() || sprite.getCollisionLayer() & spr.getCollisionMask()) &&
+        PhysicsEngine.staticAABB(broadBox, sprCollider)
       ) {
         possibleSprites.push(spr);
       }


### PR DESCRIPTION
When checking for collisions, the physics engine will check the collision layer and collision mask of colliderA and colliderB. If there is not overlap, then the possibility of a collision is discarded. If the engine detects that the colliding shape is not visible, then it will not check for collisions with it.

The collision layer and mask must be passed into the constructors of any physics body that extends from CollisionBody.