### PR TITLE
Fix collision issues with 3 colliders

### DIFF
--- a/src/math/vector2.ts
+++ b/src/math/vector2.ts
@@ -172,6 +172,14 @@ export class Vector2 {
     return new Vector2(this.x, this.y);
   }
 
+  length(): number {
+    return Math.sqrt((this.x * this.x) + (this.y * this.y));
+  }
+
+  lengthSquared(): number {
+    return (this.x * this.x) + (this.y * this.y);
+  }
+
   /**
    * Checks if this vector is equal to another vector.
    * @param {Vector2} vector2 The vector to be compared to.

--- a/test/src/index.ts
+++ b/test/src/index.ts
@@ -1,7 +1,7 @@
 import { MerlinEngine } from "../../src/index";
 import { TestGame } from "./test";
 
-const engine = new MerlinEngine(true, true, true);
+const engine = new MerlinEngine(false, true, true);
 const game = new TestGame();
 game.load().then(() => {
   engine.pushState(game);


### PR DESCRIPTION
Fix the collision issues described in #10 by not sorting the colliders by type, only by distance during the collision detection. The colliders may be swapped before checking collision based on their velocities. The collider with the greater velocity will be colliderA.