### PR TITLE
Update regionB's regionsInside property

### DIFF
--- a/src/gameObjects/physicsObjects.ts
+++ b/src/gameObjects/physicsObjects.ts
@@ -80,12 +80,10 @@ export class Region extends CollisionObject {
       // If inside, but wasn't last frame
       this.regionsInside.push(region);
       this.onRegionEnter(region);
-      region.onRegionEnter(this);
     } else if (!intersecting && containsRegion) {
       // If not inside, but was last frame
       this.regionsInside.splice(this.regionsInside.indexOf(region), 1);
       this.onRegionExit(region);
-      region.onRegionExit(this);
     }
   }
 

--- a/src/physicsEngine/physics.ts
+++ b/src/physicsEngine/physics.ts
@@ -505,7 +505,9 @@ export class PhysicsEngine {
 
       for (let x = 0; x < allBodies.length; x++) {
         const sprite2 = allBodies[x];
-        if (region != sprite2) region.interactWithRegion(sprite2);
+        if (region === sprite2) continue;
+        region.interactWithRegion(sprite2);
+        sprite2.interactWithRegion(region);
       }
     }
   }

--- a/test/src/test.ts
+++ b/test/src/test.ts
@@ -1,6 +1,6 @@
 import { TextureRect, ColorRect } from "../../src/gameObjects/cameraObjects";
 import { GameObjectTree } from "../../src/gameObjects/gameObjectTree";
-import { AABB, StaticBody, KinematicBody, RigidBody } from "../../src/gameObjects/physicsObjects";
+import { AABB, StaticBody, KinematicBody, RigidBody, Region } from "../../src/gameObjects/physicsObjects";
 import { GameState } from "../../src/gameState";
 import { log, keyboardHandler } from "../../src/index";
 import { Vector2 } from "../../src/math/vector2";
@@ -47,7 +47,11 @@ export class TestGame extends GameState {
       
       new StaticBody(new Vector2(0, 0), new Vector2(512, 128), 0b1, 0b1, 0.8, "ceiling")
         .addChild(new AABB(Vector2.zero(), new Vector2(1280, 128), true, "ceilingCollider"))
-        .addChild(new ColorRect(Vector2.zero(), new Vector2(1280, 128), "#00ff00", "ceilingTexture"))
+        .addChild(new ColorRect(Vector2.zero(), new Vector2(1280, 128), "#00ff00", "ceilingTexture")),
+
+      new TestingRegion(new Vector2(512, Utils.GAME_HEIGHT - 256), new Vector2(128, 128), "region1")
+        .addChild(new AABB(Vector2.zero(), new Vector2(128, 128), true, "region1Collider"))
+        .addChild(new ColorRect(Vector2.zero(), new Vector2(128, 128), "purple", "region1Texture")),
     ]);
   }
 
@@ -57,6 +61,18 @@ export class TestGame extends GameState {
 
   override draw() {
     this.objectTree.draw();
+  }
+}
+
+class TestingRegion extends Region {
+  constructor(position: Vector2, size: Vector2, name: string) {
+    super(position, size, 0b1, 0b1, name);
+  }
+
+  override update(dt: number): void {
+    let regionsInsideNames: string[] = [];
+    this.regionsInside.forEach((region: Region) => regionsInsideNames.push(region.getName()));
+    log("RegionsInside: ", regionsInsideNames);
   }
 }
 
@@ -365,6 +381,7 @@ class Player extends KinematicBody {
   }
 
   override update(dt: number) {
+    log("playerRegionsInside: ", this.regionsInside.map((region: Region) => region.getName()));
     const pressLeft: boolean = keyboardHandler.isKeyDown("KeyA");
     const pressRight: boolean = keyboardHandler.isKeyDown("KeyD");
     if (pressLeft == pressRight) {


### PR DESCRIPTION
Update the regionsInside property of regionB when interacting regions. The interactWithRegion method on regions only updates itself, and the interactWithRegion method is called on both regionA and regionB.